### PR TITLE
fix: typo in languages link

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
         <strong>Change</strong> the value of <code>username=</code> to your GitHub&#39;s username.
         <br>
         <br></p>
-    <pre><code class="lang-md">  [<span class="hljs-string">![My languages</span>](<span class="hljs-link">https://github-stats-evirunurm.vercel.app/api/langauges.js?username=evirunurm</span>)](<span class="hljs-link">https://github.com/evirunurm/github-stats</span>)
+    <pre><code class="lang-md">  [<span class="hljs-string">![My languages</span>](<span class="hljs-link">https://github-stats-evirunurm.vercel.app/api/languages.js?username=evirunurm</span>)](<span class="hljs-link">https://github.com/evirunurm/github-stats</span>)
 </code></pre>
     <p><br>
         <code>/api/languages.js</code> endpoint accepts the following parameters.<br>


### PR DESCRIPTION
Saw your post on reddit and checked it out. Cool.

The languages example link didn't work at first until I noticed the misspelling.