### PR TITLE
feat(security): add input validation for username, color, and boolean params

### DIFF
--- a/api/languages.js
+++ b/api/languages.js
@@ -1,6 +1,7 @@
 const userData = require("../scripts/fetchers/fetchLanguages");
 const pieChart = require("../scripts/renderers/renderLangPie");
 const barChart = require("../scripts/renderers/renderLangPercent");
+const { VALID_USERNAME } = require("../scripts/utils/validators");
 
 // FOR DEV PURPOSES
 // const express = require("express");
@@ -44,7 +45,18 @@ const barChart = require("../scripts/renderers/renderLangPercent");
 module.exports = async (req, res) => {
     const username = req.query.username;
     const color = req.query.color;
-    const pie = (req.query.pie !== "false");
+    const rawPie = req.query.pie;
+    const pie = (rawPie !== "false");
+
+    if (!VALID_USERNAME.test(username)) {
+        return res.status(400).send('Invalid username');
+    }
+    if (color !== undefined && color !== "white") {
+        return res.status(400).send('Invalid color');
+    }
+    if (rawPie !== undefined && rawPie !== "true" && rawPie !== "false") {
+        return res.status(400).send('Invalid pie');
+    }
 
     try {
         const data = await userData.fetchUserData(username);

--- a/api/stats.js
+++ b/api/stats.js
@@ -1,5 +1,6 @@
 const userData = require("../scripts/fetchers/fetchUserData");
 const card = require("../scripts/renderers/renderStatCard");
+const { VALID_USERNAME } = require("../scripts/utils/validators");
 
 // FOR DEV PURPOSES
 // const express = require("express");
@@ -27,7 +28,18 @@ const card = require("../scripts/renderers/renderStatCard");
 module.exports = async (req, res) => {
     const username = req.query.username;
     const color = req.query.color;
-    const peng = (req.query.peng !== "false");
+    const rawPeng = req.query.peng;
+    const peng = (rawPeng !== "false");
+
+    if (!VALID_USERNAME.test(username)) {
+        return res.status(400).send('Invalid username');
+    }
+    if (color !== undefined && color !== "white") {
+        return res.status(400).send('Invalid color');
+    }
+    if (rawPeng !== undefined && rawPeng !== "true" && rawPeng !== "false") {
+        return res.status(400).send('Invalid peng');
+    }
 
     try {
         const data = await userData.fetchUserData(username);

--- a/scripts/utils/validators.js
+++ b/scripts/utils/validators.js
@@ -1,0 +1,3 @@
+const VALID_USERNAME = /^[a-zA-Z0-9-]{1,39}$/;
+
+exports.VALID_USERNAME = VALID_USERNAME;


### PR DESCRIPTION
## Summary

- Validates `username` against the GitHub username regex (`/^[a-zA-Z0-9-]{1,39}$/`) before interpolating into GraphQL queries, preventing injection via string interpolation
- Rejects unknown `color` values (only `"white"` or omitted are valid)
- Validates `pie` and `peng` boolean flags — must be `"true"`, `"false"`, or omitted
- Extracted shared `VALID_USERNAME` regex to `scripts/utils/validators.js`

Closes #5

## Test plan

- [x] Request `/api/stats?username=valid-user` → returns SVG
- [x] Request `/api/stats?username="><script>` → returns 400 Invalid username
- [x] Request `/api/stats?username=valid-user&color=white` → returns light-theme SVG
- [x] Request `/api/stats?username=valid-user&color=red` → returns 400 Invalid color
- [x] Request `/api/languages?username=valid-user&pie=false` → returns bar chart SVG
- [x] Request `/api/languages?username=valid-user&pie=maybe` → returns 400 Invalid pie
- [x] Request `/api/stats?username=valid-user&peng=false` → returns SVG without penguin
- [x] Request `/api/stats?username=valid-user&peng=yes` → returns 400 Invalid peng

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)