### PR TITLE
fix: add error handling and resilience (phase 5)

### DIFF
--- a/api/languages.js
+++ b/api/languages.js
@@ -1,6 +1,7 @@
 const userData = require("../scripts/fetchers/fetchLanguages");
 const pieChart = require("../scripts/renderers/renderLangPie");
 const barChart = require("../scripts/renderers/renderLangPercent");
+const { renderErrorCard } = require("../scripts/renderers/renderErrorCard");
 const { VALID_USERNAME } = require("../scripts/utils/validators");
 
 module.exports = async (req, res) => {
@@ -29,6 +30,7 @@ module.exports = async (req, res) => {
         }
         return res.send(barChart.renderLanguageCard(data, color));
     } catch (err) {
-        res.status(500).send("Couldn´t fetch your data. Double-check your username is the same as your GitHubs's. Don't include the '@'. If it still doen't work plase send an email to evelinviru@gmail.com :(");
+        res.setHeader("Content-Type", "image/svg+xml");
+        res.status(500).send(renderErrorCard("Could not fetch data"));
     }
 };

--- a/api/stats.js
+++ b/api/stats.js
@@ -1,5 +1,6 @@
 const userData = require("../scripts/fetchers/fetchUserData");
 const card = require("../scripts/renderers/renderStatCard");
+const { renderErrorCard } = require("../scripts/renderers/renderErrorCard");
 const { VALID_USERNAME } = require("../scripts/utils/validators");
 
 module.exports = async (req, res) => {
@@ -25,6 +26,7 @@ module.exports = async (req, res) => {
         res.setHeader("Cache-Control", `public, max-age=${cacheSeconds}`);
         return res.send(card.renderStatCard(data, color, peng));
     } catch (err) {
-        res.status(500).send("Couldn´t fetch your data. Double-check your username is the same as your GitHubs's. Don't include the '@'. If it still doen't work plase send an email to evelinviru@gmail.com :(");
+        res.setHeader("Content-Type", "image/svg+xml");
+        res.status(500).send(renderErrorCard("Could not fetch data"));
     }
 };

--- a/scripts/fetchers/fetchLanguages.js
+++ b/scripts/fetchers/fetchLanguages.js
@@ -46,7 +46,11 @@ const fetchUserData = async (user) => {
 			});
 
 			res.on("end", () => {
-				resolve(JSON.parse(body));
+				try {
+					resolve(JSON.parse(body));
+				} catch (e) {
+					reject(new Error(`Failed to parse GitHub API response: ${e.message}`));
+				}
 			});
 		});
 

--- a/scripts/fetchers/fetchUserData.js
+++ b/scripts/fetchers/fetchUserData.js
@@ -48,7 +48,11 @@ totalCount
 			});
 
 			res.on("end", () => {
-				resolve(JSON.parse(body));
+				try {
+					resolve(JSON.parse(body));
+				} catch (e) {
+					reject(new Error(`Failed to parse GitHub API response: ${e.message}`));
+				}
 			});
 		});
 

--- a/scripts/renderers/renderErrorCard.js
+++ b/scripts/renderers/renderErrorCard.js
@@ -1,0 +1,17 @@
+const renderErrorCard = (message) => {
+	return `<svg
+		width="290"
+		height="160"
+		viewBox="0 0 290 160"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+		style="border-radius: 10px;"
+	>
+		<rect rx="10" ry="10" height="100%" width="100%" fill="#161B22" stroke-opacity="1" style="stroke:#A4A5A6;stroke-width:1;" />
+		<text x="145" y="70" text-anchor="middle" style="font: 600 14px 'Segoe UI', Ubuntu, Sans-Serif; fill:#FF6B6B;">Error</text>
+		<line x1="29" x2="261" y1="84" y2="84" stroke="#A4A5A6" />
+		<text x="145" y="108" text-anchor="middle" style="font: 400 12px 'Segoe UI', Ubuntu, Sans-Serif; fill:#A4A5A6;">${message}</text>
+	</svg>`;
+};
+
+exports.renderErrorCard = renderErrorCard;

--- a/scripts/renderers/renderLangPie.js
+++ b/scripts/renderers/renderLangPie.js
@@ -45,15 +45,15 @@ const renderLanguageCard = (userData, color) => {
 			.slice(0, 5);
 
 		const totalCount = langStats
-			// Gets langauge count
 			.reduce((accumulator, language) => {
 				return accumulator + language.count;
 			}, 0);
 
-		for (let i = 0; i < langStats.length; i++) {
+		for (let i = 0; i < langStats.length - 1; i++) {
 			langStats[i].count = Math.round((100 * langStats[i].count) / totalCount);
 		}
-
+		const sumOfOthers = langStats.slice(0, -1).reduce((acc, lang) => acc + lang.count, 0);
+		langStats[langStats.length - 1].count = 100 - sumOfOthers;
 
 		langStats
 			.sort((a, b) => {
@@ -64,32 +64,21 @@ const renderLanguageCard = (userData, color) => {
 				return accumulator + language.count
 			}, 0);
 
-		// In case there's 1% error while rounding.
-		if (langStats[langStats.length - 1].accum + langStats[langStats.length - 1].count !== 100) {
-			langStats[langStats.length - 1].count++;
-		}
-
 		return langStats;
 	}
 
+	const languageStats = calcPercentages(userData.languages);
+	const languageStatsDesc = [...languageStats].sort((a, b) => b.count - a.count);
+
 	const createCircles = () => {
-		const languagePercentages = calcPercentages(userData.languages);
-
-		let circles = [];
-
-		for (var i = 0; i < languagePercentages.length; i++) {
-			circles.push(
-				`<circle r="5" cx="10" cy="10" fill="transparent"
-                    stroke="${ languagePercentages[i].color }"
+		return languageStats.map(lang =>
+			`<circle r="5" cx="10" cy="10" fill="transparent"
+                    stroke="${ lang.color }"
                     stroke-width="10"
-                    stroke-dasharray="calc(${ languagePercentages[i].count + languagePercentages[i].accum } * 31.4 / 100) 31.4"
+                    stroke-dasharray="calc(${ lang.count + lang.accum } * 31.4 / 100) 31.4"
                     transform="rotate(-90) translate(-20)"
                 />`
-			);
-		}
-
-		circles = circles.reverse();
-		return circles;
+		).reverse();
 	}
 
 	const cardAttr = {
@@ -97,11 +86,7 @@ const renderLanguageCard = (userData, color) => {
 		height: 160,
 		background: `${ (color === "white") ? "white" : "#161B22"}`,
 		style: "border-radius: 10px;",
-		children: calcPercentages(userData.languages)
-			.sort((a, b) => {
-				return b.count - a.count;
-			})
-			.reduce((acc, item) => [...acc, item.name], ["Most used languages"])
+		children: languageStatsDesc.reduce((acc, item) => [...acc, item.name], ["Most used languages"])
 	}
 
 	const mountText = () => {
@@ -138,12 +123,7 @@ const renderLanguageCard = (userData, color) => {
 			"
 		/> 
 		${ cardAttr.children.map(child => child).join('') }
-		${ calcPercentages(userData.languages)
-			.sort((a, b) => {
-				return b.count - a.count;
-			})
-			.reduce((acc, item) => [...acc, {name: item.name, color:  item.color}], [])
-			.map( (child, index) => createIcon(child, index + 1)) }
+		${ languageStatsDesc.map((child, index) => createIcon(child, index + 1)) }
 		<svg x="${ ((cardAttr.width / 2) + ((userData.user + "@'s GitHub").length / 2 * ((textAttr.fontSize + 2) / 2))) }" y="${ (cardAttr.height / (6) - 6) }" width="19" height="15" viewBox="0 0 19 15" fill="none" xmlns="http://www.w3.org/2000/svg">
 			${ color === "white" ? svgs.githubCat : svgs.githubCatW }
 		</svg>


### PR DESCRIPTION
## Summary

- **Silent JSON.parse failures**: both fetchers now wrap `JSON.parse` in try/catch and properly call `reject` when the GitHub API returns non-JSON (e.g. rate-limit responses)
- **SVG error card on failure**: API endpoints now return `Content-Type: image/svg+xml` with a visible error card instead of plain text, preventing broken image icons in READMEs
- **Rounding fix in `renderLangPie`**: replaced the brittle `+1` correction (only handled off-by-1) with a robust last-element remainder approach — percentages now always sum to exactly 100
- **Perf**: `calcPercentages()` is now computed once per render instead of three times (was doing deep-copy + sort on every call)

Closes #7

## Test plan

- [x] Hit `/api/stats.js?username=validuser` — returns SVG stat card
- [x] Hit `/api/languages.js?username=validuser` — returns SVG pie/bar card
- [ ] Simulate a rate-limit (non-JSON) response from GitHub — verify the promise rejects cleanly and the API responds with an SVG error card (not a broken image)
- [ ] Verify pie chart percentages always sum to 100 with edge-case inputs (e.g. 1 or 2 languages, uneven distributions)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)