### PR TITLE
feat(types): add shared TypeScript interfaces for GitHub API and stats

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "resolveJsonModule": true,
     "allowJs": true
   },
-  "include": ["api/**/*", "scripts/**/*"],
+  "include": ["api/**/*", "scripts/**/*", "types/**/*"],
   "exclude": ["node_modules", "dist", "tests"]
 }

--- a/types/github.ts
+++ b/types/github.ts
@@ -1,0 +1,40 @@
+export interface GitHubLanguageNode {
+  name: string;
+  color: string;
+}
+
+export interface GitHubLanguageEdge {
+  node: GitHubLanguageNode;
+}
+
+export interface GitHubRepositoryNode {
+  forkCount?: number;
+  stargazerCount?: number;
+  languages?: {
+    edges: GitHubLanguageEdge[];
+  };
+}
+
+export interface GitHubRepositoryEdge {
+  node: GitHubRepositoryNode;
+}
+
+export interface GitHubUser {
+  repositories: {
+    edges: GitHubRepositoryEdge[];
+  };
+  contributionsCollection?: {
+    contributionCalendar: {
+      totalContributions: number;
+    };
+  };
+  followers?: {
+    totalCount: number;
+  };
+}
+
+export interface GitHubApiResponse {
+  data: {
+    user: GitHubUser;
+  };
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,4 @@
+export * from "./github";
+export * from "./language";
+export * from "./stats";
+export * from "./vercel";

--- a/types/language.ts
+++ b/types/language.ts
@@ -1,0 +1,5 @@
+export interface LanguageData {
+  name: string;
+  color: string;
+  count: number;
+}

--- a/types/stats.ts
+++ b/types/stats.ts
@@ -1,0 +1,15 @@
+import { LanguageData } from "./language";
+
+export interface UserStats {
+  user: string;
+  amountFollowers: number;
+  amountRepos: number;
+  amountStars: number;
+  amountForks: number;
+  totalContributions: number;
+}
+
+export interface UserLanguageStats {
+  user: string;
+  languages: LanguageData[];
+}

--- a/types/vercel.ts
+++ b/types/vercel.ts
@@ -1,0 +1,4 @@
+import type { Request, Response } from "express";
+
+export type VercelRequest = Request;
+export type VercelResponse = Response;


### PR DESCRIPTION
## Summary

- Creates `types/` directory with shared TypeScript interfaces (closes #20)
- `GitHubUser` / `GitHubApiResponse` — GraphQL response shapes matching actual queries in `fetchUserData.js` and `fetchLanguages.js`
- `LanguageData` — `{ name: string; color: string; count: number }`
- `UserStats` / `UserLanguageStats` — aggregated data shapes passed to the stat and language card renderers
- `VercelRequest` / `VercelResponse` — type aliases from `@types/express` (already a dev dependency)
- Updates `tsconfig.json` include to cover `types/**/*`

## Test plan

- [x] `npm run typecheck` passes with no errors
- [x] All interfaces in `types/` reflect the actual runtime shapes used in fetchers and renderers

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)