### PR TITLE
fix: redirect legacy .js API routes to extension-less routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "redirects": [
+    { "source": "/api/stats.js", "destination": "/api/stats", "permanent": true },
+    { "source": "/api/languages.js", "destination": "/api/languages", "permanent": true }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `vercel.json` with permanent (301) redirects from the legacy `.js` routes to the clean routes:
  - `/api/stats.js` → `/api/stats`
  - `/api/languages.js` → `/api/languages`

Vercel never exposes file extensions in serverless function URLs, so `/api/stats.js` was always a 404. This ensures any existing README embeds or bookmarks using the old `.js` URLs continue to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)