### PR TITLE
feat(ts): add typecheck to CI and finalize TypeScript migration (phase 7)

### DIFF
--- a/api/languages.ts
+++ b/api/languages.ts
@@ -1,22 +1,10 @@
 import { VALID_USERNAME } from "../scripts/utils/validators";
 import { CACHE_DURATION_SECONDS } from "../scripts/utils/constants";
 import type { VercelRequest, VercelResponse } from "../types/vercel";
-import type { UserLanguageStats } from "../types";
-
-/* eslint-disable @typescript-eslint/no-require-imports */
-const fetcherModule = require("../scripts/fetchers/fetchLanguages") as {
-    fetchUserData: (user: string) => Promise<UserLanguageStats>;
-};
-const pieChartModule = require("../scripts/renderers/renderLangPie") as {
-    renderLanguageCard: (userData: UserLanguageStats, color: string) => string;
-};
-const barChartModule = require("../scripts/renderers/renderLangPercent") as {
-    renderLanguageCard: (userData: UserLanguageStats, color: string) => string;
-};
-const errorModule = require("../scripts/renderers/renderErrorCard") as {
-    renderErrorCard: (message: string) => string;
-};
-/* eslint-enable @typescript-eslint/no-require-imports */
+import { fetchUserData } from "../scripts/fetchers/fetchLanguages";
+import { renderLanguageCard as renderLangPie } from "../scripts/renderers/renderLangPie";
+import { renderLanguageCard as renderLangPercent } from "../scripts/renderers/renderLangPercent";
+import { renderErrorCard } from "../scripts/renderers/renderErrorCard";
 
 export default async (req: VercelRequest, res: VercelResponse): Promise<void> => {
     const username = req.query.username as string;
@@ -38,16 +26,16 @@ export default async (req: VercelRequest, res: VercelResponse): Promise<void> =>
     }
 
     try {
-        const data = await fetcherModule.fetchUserData(username);
+        const data = await fetchUserData(username);
         res.setHeader("Content-Type", "image/svg+xml");
         res.setHeader("Cache-Control", `public, max-age=${CACHE_DURATION_SECONDS}`);
         if (pie) {
-            res.send(pieChartModule.renderLanguageCard(data, color ?? ""));
+            res.send(renderLangPie(data, color ?? ""));
             return;
         }
-        res.send(barChartModule.renderLanguageCard(data, color ?? ""));
+        res.send(renderLangPercent(data, color ?? ""));
     } catch {
         res.setHeader("Content-Type", "image/svg+xml");
-        res.status(500).send(errorModule.renderErrorCard("Could not fetch data"));
+        res.status(500).send(renderErrorCard("Could not fetch data"));
     }
 };

--- a/api/stats.ts
+++ b/api/stats.ts
@@ -1,19 +1,9 @@
 import { VALID_USERNAME } from "../scripts/utils/validators";
 import { CACHE_DURATION_SECONDS } from "../scripts/utils/constants";
 import type { VercelRequest, VercelResponse } from "../types/vercel";
-import type { UserStats } from "../types";
-
-/* eslint-disable @typescript-eslint/no-require-imports */
-const fetcherModule = require("../scripts/fetchers/fetchUserData") as {
-    fetchUserData: (user: string) => Promise<UserStats>;
-};
-const rendererModule = require("../scripts/renderers/renderStatCard") as {
-    renderStatCard: (userData: UserStats, color: string, peng: boolean) => string;
-};
-const errorModule = require("../scripts/renderers/renderErrorCard") as {
-    renderErrorCard: (message: string) => string;
-};
-/* eslint-enable @typescript-eslint/no-require-imports */
+import { fetchUserData } from "../scripts/fetchers/fetchUserData";
+import { renderStatCard } from "../scripts/renderers/renderStatCard";
+import { renderErrorCard } from "../scripts/renderers/renderErrorCard";
 
 export default async (req: VercelRequest, res: VercelResponse): Promise<void> => {
     const username = req.query.username as string;
@@ -35,12 +25,12 @@ export default async (req: VercelRequest, res: VercelResponse): Promise<void> =>
     }
 
     try {
-        const data = await fetcherModule.fetchUserData(username);
+        const data = await fetchUserData(username);
         res.setHeader("Content-Type", "image/svg+xml");
         res.setHeader("Cache-Control", `public, max-age=${CACHE_DURATION_SECONDS}`);
-        res.send(rendererModule.renderStatCard(data, color ?? "", peng));
+        res.send(renderStatCard(data, color ?? "", peng));
     } catch {
         res.setHeader("Content-Type", "image/svg+xml");
-        res.status(500).send(errorModule.renderErrorCard("Could not fetch data"));
+        res.status(500).send(renderErrorCard("Could not fetch data"));
     }
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,6 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
-  testMatch: ["**/tests/**/*.test.ts", "**/tests/**/*.test.js"],
+  testMatch: ["**/tests/**/*.test.ts"],
   moduleFileExtensions: ["ts", "js", "json"],
 };

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "scripts": {
     "test": "jest",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint \"api/**/*.{js,ts}\" \"scripts/**/*.{js,ts}\"",
-    "format": "prettier --write \"api/**/*.{js,ts}\" \"scripts/**/*.{js,ts}\""
+    "lint": "eslint \"api/**/*.{js,ts}\" \"scripts/**/*.{js,ts}\" \"tests/**/*.ts\"",
+    "format": "prettier --write \"api/**/*.{js,ts}\" \"scripts/**/*.{js,ts}\" \"tests/**/*.ts\""
   },
   "repository": {
     "type": "git",

--- a/scripts/fetchers/fetchLanguages.ts
+++ b/scripts/fetchers/fetchLanguages.ts
@@ -109,5 +109,4 @@ const fetchUserData = async (user: string): Promise<UserLanguageStats> => {
 	return getDataObj(data);
 };
 
-// PROD
-exports.fetchUserData = fetchUserData;
+export { fetchUserData };

--- a/scripts/fetchers/fetchUserData.ts
+++ b/scripts/fetchers/fetchUserData.ts
@@ -114,4 +114,4 @@ totalCount
 	return getDataObj(data);
 };
 
-exports.fetchUserData = fetchUserData;
+export { fetchUserData };

--- a/scripts/renderers/renderErrorCard.ts
+++ b/scripts/renderers/renderErrorCard.ts
@@ -16,4 +16,4 @@ const renderErrorCard = (message: string): string => {
 	</svg>`;
 };
 
-exports.renderErrorCard = renderErrorCard;
+export { renderErrorCard };

--- a/scripts/renderers/renderLangPercent.ts
+++ b/scripts/renderers/renderLangPercent.ts
@@ -128,5 +128,4 @@ const renderLanguageCard = (userData: UserLanguageStats, color: string): string 
 	</svg>`;
 }
 
-exports.renderLanguageCard = renderLanguageCard;
-exports.calcPercentages = calcPercentages;
+export { renderLanguageCard, calcPercentages };

--- a/scripts/renderers/renderLangPie.ts
+++ b/scripts/renderers/renderLangPie.ts
@@ -159,5 +159,4 @@ const renderLanguageCard = (userData: UserLanguageStats, color: string): string 
 
 }
 
-exports.renderLanguageCard = renderLanguageCard;
-exports.calcPercentages = calcPercentages;
+export { renderLanguageCard, calcPercentages };

--- a/scripts/renderers/renderStatCard.ts
+++ b/scripts/renderers/renderStatCard.ts
@@ -129,4 +129,4 @@ const renderStatCard = (userData: UserStats, color: string, peng: boolean): stri
 	</svg>`;
 }
 
-exports.renderStatCard = renderStatCard;
+export { renderStatCard };

--- a/tests/calcPercentages.test.ts
+++ b/tests/calcPercentages.test.ts
@@ -1,7 +1,8 @@
-const { calcPercentages: calcPercentagesPie } = require('../scripts/renderers/renderLangPie');
-const { calcPercentages: calcPercentagesBar } = require('../scripts/renderers/renderLangPercent');
+import { calcPercentages as calcPercentagesPie } from '../scripts/renderers/renderLangPie';
+import { calcPercentages as calcPercentagesBar } from '../scripts/renderers/renderLangPercent';
+import { LanguageData } from '../types';
 
-const mockLanguages = [
+const mockLanguages: LanguageData[] = [
 	{ name: 'JavaScript', color: '#f1e05a', count: 50 },
 	{ name: 'Python', color: '#3572A5', count: 30 },
 	{ name: 'TypeScript', color: '#2b7489', count: 10 },

--- a/tests/renderErrorCard.test.ts
+++ b/tests/renderErrorCard.test.ts
@@ -1,5 +1,5 @@
-const { renderErrorCard } = require('../scripts/renderers/renderErrorCard');
-const { CARD_WIDTH, CARD_HEIGHT } = require('../scripts/utils/constants');
+import { renderErrorCard } from '../scripts/renderers/renderErrorCard';
+import { CARD_WIDTH, CARD_HEIGHT } from '../scripts/utils/constants';
 
 describe('renderErrorCard', () => {
 	test('returns an SVG string', () => {

--- a/tests/validators.test.ts
+++ b/tests/validators.test.ts
@@ -1,4 +1,4 @@
-const { VALID_USERNAME } = require('../scripts/utils/validators');
+import { VALID_USERNAME } from '../scripts/utils/validators';
 
 describe('VALID_USERNAME', () => {
 	test('accepts valid usernames', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "resolveJsonModule": true,
     "allowJs": true
   },
-  "include": ["api/**/*", "scripts/**/*", "types/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": ["api/**/*", "scripts/**/*", "types/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

- Migrate all three test files (`tests/*.test.js`) to TypeScript (`tests/*.test.ts`) with proper type annotations and ES module imports
- Replace all `exports.xxx =` CommonJS-style assignments in `scripts/` fetchers and renderers with proper `export { ... }` ES module syntax
- Update `api/languages.ts` and `api/stats.ts` to use proper ES `import` statements, eliminating the `require()` + `eslint-disable` escape hatches entirely
- Add `tests/` to `tsconfig.json` include and to the `lint`/`format` scripts for full project coverage
- Update `jest.config.js` `testMatch` to only match `.ts` test files

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run lint` — zero errors
- [x] `npm test` — all 18 tests pass across 3 suites

Closes #25
Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)