### PR TITLE
refactor(tests): co-locate test files with source modules

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,6 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
-  testMatch: ["**/tests/**/*.test.ts"],
+  testMatch: ["**/*.test.ts"],
   moduleFileExtensions: ["ts", "js", "json"],
 };

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "scripts": {
     "test": "jest",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint \"api/**/*.{js,ts}\" \"scripts/**/*.{js,ts}\" \"tests/**/*.ts\"",
-    "format": "prettier --write \"api/**/*.{js,ts}\" \"scripts/**/*.{js,ts}\" \"tests/**/*.ts\""
+    "lint": "eslint \"api/**/*.{js,ts}\" \"scripts/**/*.{js,ts}\"",
+    "format": "prettier --write \"api/**/*.{js,ts}\" \"scripts/**/*.{js,ts}\""
   },
   "repository": {
     "type": "git",

--- a/scripts/renderers/calcPercentages.test.ts
+++ b/scripts/renderers/calcPercentages.test.ts
@@ -1,6 +1,6 @@
-import { calcPercentages as calcPercentagesPie } from '../scripts/renderers/renderLangPie';
-import { calcPercentages as calcPercentagesBar } from '../scripts/renderers/renderLangPercent';
-import { LanguageData } from '../types';
+import { calcPercentages as calcPercentagesPie } from './renderLangPie';
+import { calcPercentages as calcPercentagesBar } from './renderLangPercent';
+import { LanguageData } from '../../types';
 
 const mockLanguages: LanguageData[] = [
 	{ name: 'JavaScript', color: '#f1e05a', count: 50 },

--- a/scripts/renderers/renderErrorCard.test.ts
+++ b/scripts/renderers/renderErrorCard.test.ts
@@ -1,5 +1,5 @@
-import { renderErrorCard } from '../scripts/renderers/renderErrorCard';
-import { CARD_WIDTH, CARD_HEIGHT } from '../scripts/utils/constants';
+import { renderErrorCard } from './renderErrorCard';
+import { CARD_WIDTH, CARD_HEIGHT } from '../utils/constants';
 
 describe('renderErrorCard', () => {
 	test('returns an SVG string', () => {

--- a/scripts/utils/validators.test.ts
+++ b/scripts/utils/validators.test.ts
@@ -1,4 +1,4 @@
-import { VALID_USERNAME } from '../scripts/utils/validators';
+import { VALID_USERNAME } from './validators';
 
 describe('VALID_USERNAME', () => {
 	test('accepts valid usernames', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "resolveJsonModule": true,
     "allowJs": true
   },
-  "include": ["api/**/*", "scripts/**/*", "types/**/*", "tests/**/*"],
+  "include": ["api/**/*", "scripts/**/*", "types/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

- Moves `tests/validators.test.ts` → `scripts/utils/validators.test.ts`
- Moves `tests/renderErrorCard.test.ts` → `scripts/renderers/renderErrorCard.test.ts`
- Moves `tests/calcPercentages.test.ts` → `scripts/renderers/calcPercentages.test.ts`
- Updates imports in each test file to use relative paths
- Updates `jest.config.js` test pattern to `**/*.test.ts`
- Removes `tests/**/*` from `tsconfig.json` include paths
- Removes `tests/**/*.ts` glob from `lint` and `format` scripts in `package.json`
- Deletes the now-empty `tests/` directory

Closes #37.

## Test plan

- [x] `npm test` — all 18 tests pass
- [x] `npm run typecheck` — no type errors
- [x] `npm run lint` — no lint errors

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)